### PR TITLE
Print info log messaged to stdout instead of stderr

### DIFF
--- a/cmd/hello-kubic/main.go
+++ b/cmd/hello-kubic/main.go
@@ -46,6 +46,7 @@ func main() {
 	if len(os.Getenv("MESSAGE")) > 0 {
 		message = os.Getenv("MESSAGE")
 	}
+  log.SetOutput(os.Stdout)
 	log.Printf("Hello-Kubic %s started\n", version)
 	http.HandleFunc("/", indexHandler)
 	http.HandleFunc("/openSUSE-Kubic-Logo.png",


### PR DESCRIPTION
Hello,

as `hello-kubic` is used as a basic check in podman_pods openQA test where also `journal_check` looks for errors it would be nice if the starting message would be printed to stdout instead of stderr.